### PR TITLE
Perform mkdirs for workspace warehouse and memos.

### DIFF
--- a/app/emerge/emerge.go
+++ b/app/emerge/emerge.go
@@ -54,6 +54,8 @@ func EvalModule(
 	wareStaging := api.WareStaging{ByPackType: map[api.PackType]api.WarehouseLocation{"tar": landmarks.StagingWarehouseLoc()}}
 	wareSourcing := api.WareSourcing{}
 	wareSourcing.AppendByPackType("tar", landmarks.StagingWarehouseLoc())
+	// Make the workspace's local warehouse dir if it doesn't exist.
+	os.Mkdir(landmarks.StagingWarehousePath(), 0755)
 
 	// Prepare catalog view tools.
 	//  Definitely includes the workspace catalog;
@@ -94,8 +96,11 @@ func EvalModule(
 		fmt.Fprintf(stderr, "  - %q: %s\n", k, pins[k])
 	}
 
-	// Configure memoization.
-	os.Setenv("REPEATR_MEMODIR", landmarks.MemoDir())
+	// Ensure memoization is enabled.
+	//  Future: this is a bit of an odd reach-around way to configure this.
+	//  PRs which propose more/better ways to enable and parameterize memoization would be extremely welcomed.
+	os.Setenv("REPEATR_MEMODIR", workspace.Layout.MemoDir())
+	os.Mkdir(workspace.Layout.MemoDir(), 0755) // Errors ignored.  Repeatr will emit warns, but work.
 
 	// Begin the evaluation!
 	exports, err := module.Evaluate(


### PR DESCRIPTION
We've historically been really cautious about creating dirs on the
filesystem if they don't already exist, as a form of defensiveness in
the event of accidental misconfiguration.

That's a caution I still stand by, in many cases, but in stellar, it's
been a bit excessive.  We have a clear line: if it's inside the
'.timeless' directory, we are *definitely* within our rights to write
it, and it should be utterly unsurprising to do so.

(And we're *not* automatically creating a '.timeless' dir.  So that's
your opt-in.)

We also *always*, as a matter of practical fact, want memoization
enabled by default.  And using the lack of a directory to gate that was
also pure implementation-detail silliness that cannot be defended.
So, now, if anyone wants a way to *disable* memoization again, PR's
will be welcome.  (I suspect it'll be a while before someone in fact
wants this.)  Meanwhile: Memoize All The Things!

It should be noted that the Repeatr and Rio tools are still cautious
about making directories; nothing about that is changing.  It's just
Stellar which is getting a little more enthusiastic.  (Within bounds!)